### PR TITLE
making file object in line with readme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,17 +254,14 @@ export default class AttachesTool {
     const body = response.body;
 
     if (body.success && body.file) {
-      const { url, name, size, title } = body.file;
+      const file = Object.assign({}, body.file);
 
-      this.data = {
-        file: {
-          url,
-          extension: name.split('.').pop(),
-          name,
-          size
-        },
-        title
-      };
+      file.extension = file.name.split('.').pop();
+
+      this.data.file = file;
+      if (!this.data.title) {
+        this.data.title = file.title ? file.title : file.name;
+      }
 
       this.nodes.button.remove();
       this.showFileData();
@@ -380,12 +377,7 @@ export default class AttachesTool {
    */
   set data({ file, title }) {
     this._data = Object.assign({}, {
-      file: {
-        url: (file && file.url) || this._data.file.url,
-        name: (file && file.name) || this._data.file.name,
-        extension: (file && file.extension) || this._data.file.extension,
-        size: (file && file.size) || this._data.file.size
-      },
+      file: file || {},
       title: title || this._data.title
     });
   }


### PR DESCRIPTION
The readme states that all fields are optional in the file object returned by the endpoint, and that additional fields may be returned by the endpoint and saved.

In fact the fields url, name, size, and title were being assumed to exist, and arbitrary additional fields were being discarded. This makes the behavior line up with the documentation, and allows fields to be omitted, or for arbitrary additional fields to be returned by the endpoint and saved.

This addresses issue #15 as I also needed support for optional fields to be able to use this tool for my purposes.