### PR TITLE
Trigger onChange on editor when file uploaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/attaches",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": "https://github.com/editor-js/attaches",
   "license": "MIT",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,11 @@ export default class AttachesTool {
       console.error('Attaches tool error:', error);
       this.uploadingFailed(this.config.errorMessage);
     }
+    
+    /**
+     * Trigger onChange function when upload finished
+     */
+    this.api.blocks.getBlockByIndex(this.api.blocks.getCurrentBlockIndex()).dispatchChange();
   }
 
   /**


### PR DESCRIPTION
fixes #50

If preferred, I can also change it to access the `BlockAPI` directly. Like this: https://editorjs.io/blockapi