### PR TITLE
Remove no need title field in file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/attaches",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": "https://github.com/editor-js/attaches",
   "license": "MIT",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,12 @@ export default class AttachesTool {
     try {
       if (body.success && body.file !== undefined && !isEmpty(body.file)) {
         this.data = {
-          file: body.file,
+          file: {
+            url: body.file.url || '',
+            name: body.file.name || '',
+            extension: body.file.extension || '',
+            size: body.file.size || '',
+          },
           title: body.file.title || '',
         };
 


### PR DESCRIPTION
Tools returns title twice. it is not ok

```
{
  'title': ...
  
  'file': {
    'title': ...
  }   
}
```  