### PR TITLE
Removes rel attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/attaches",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repository": "https://github.com/editor-js/attaches",
   "license": "MIT",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -441,7 +441,6 @@ export default class AttachesTool {
         innerHTML: IconChevronDown,
         href: file.url,
         target: '_blank',
-        rel: 'nofollow noindex noreferrer',
       });
 
       this.nodes.wrapper.appendChild(downloadIcon);


### PR DESCRIPTION
Fixes https://github.com/editor-js/attaches/issues/76 

Removes the `rel` attribute from the `a`-tag
====

**Explanations:**

There is no "noindex" value for the [rel](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel) HTML attribute. 

The [nofollow attribute ](https://ahrefs.com/seo/glossary/nofollow) was used in the past to tell search engines to simply ignore a link. Google would not crawl these links and did not pass value through them. Their treatment of nofollow links changed in 2020 and now it’s more complicated. They treat nofollow as a hint, which means they can choose to crawl and pass value through them, or not.

[Noreferrer](https://ahrefs.com/seo/glossary/noreferrer) is related to analytics and tracking. The referrer value shows the previous page where a user came from. By using the noreferrer attribute on a link, you are preventing other pages from seeing that traffic came from a click on your link.

→ Some APIs do validate the referer to access a file and so we can remove that value.